### PR TITLE
fix: remove pnpm-workspace.yaml and upgrade pnpm to v10

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
       - name: Checkout
         uses: actions/checkout@v4
       - name: Detect package manager

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - core-js


### PR DESCRIPTION
- Remove invalid pnpm-workspace.yaml that caused ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION
- Upgrade GitHub Actions pnpm version from 8 to 10